### PR TITLE
Fix paths in iOS project file

### DIFF
--- a/frontend/ios-app/LocationApp.xcodeproj/project.pbxproj
+++ b/frontend/ios-app/LocationApp.xcodeproj/project.pbxproj
@@ -1,4 +1,4 @@
-// !$*UTF8*$!
+ // !$*UTF8*$!
 {
 	archiveVersion = 1;
 	classes = {
@@ -7,21 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		1D60588D0D05DD3D006BFB54 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D60588C0D05DD3D006BFB54 /* AppDelegate.swift */; };
-		1D60588E0D05DD3D006BFB54 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1D60588F0D05DD3D006BFB54 /* Main.storyboard */; };
-		1D6058900D05DD3D006BFB54 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1D6058910D05DD3D006BFB54 /* Assets.xcassets */; };
-		1D6058920D05DD3D006BFB54 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1D6058930D05DD3D006BFB54 /* LaunchScreen.storyboard */; };
+		 1D60588D0D05DD3D006BFB54 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D60588C0D05DD3D006BFB54 /* AppDelegate.swift */; };
 		1D6058940D05DD3D006BFB54 /* LocationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6058950D05DD3D006BFB54 /* LocationListViewController.swift */; };
 		1D6058960D05DD3D006BFB54 /* UserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D6058970D05DD3D006BFB54 /* UserProfileViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		1D60588C0D05DD3D006BFB54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		1D60588F0D05DD3D006BFB54 /* Main.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
-		1D6058910D05DD3D006BFB54 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		1D6058930D05DD3D006BFB54 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
-		1D6058950D05DD3D006BFB54 /* LocationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationListViewController.swift; sourceTree = "<group>"; };
-		1D6058970D05DD3D006BFB54 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileViewController.swift; sourceTree = "<group>"; };
+		1D60588C0D05DD3D006BFB54 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/AppDelegate.swift; sourceTree = "<group>"; };
+		1D6058950D05DD3D006BFB54 /* LocationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/LocationListViewController.swift; sourceTree = "<group>"; };
+		1D6058970D05DD3D006BFB54 /* UserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sources/UserProfileViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -29,9 +23,6 @@
 			isa = PBXGroup;
 			children = (
 				1D60588C0D05DD3D006BFB54 /* AppDelegate.swift */,
-				1D60588F0D05DD3D006BFB54 /* Main.storyboard */,
-				1D6058910D05DD3D006BFB54 /* Assets.xcassets */,
-				1D6058930D05DD3D006BFB54 /* LaunchScreen.storyboard */,
 				1D6058950D05DD3D006BFB54 /* LocationListViewController.swift */,
 				1D6058970D05DD3D006BFB54 /* UserProfileViewController.swift */,
 			);


### PR DESCRIPTION
Adjust the paths of files referenced in `frontend/ios-app/LocationApp.xcodeproj/project.pbxproj`.

* Adjust the path for `AppDelegate.swift` to `Sources/AppDelegate.swift`.
* Adjust the path for `LocationListViewController.swift` to `Sources/LocationListViewController.swift`.
* Adjust the path for `UserProfileViewController.swift` to `Sources/UserProfileViewController.swift`.
* Remove the references to `Main.storyboard`, `Assets.xcassets`, and `LaunchScreen.storyboard`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ComiR/location-app?shareId=90f996ef-e9d7-4e7b-8039-432d89a9e8d3).